### PR TITLE
ci: bump codeql-action as one unit and group its future updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -26,3 +26,10 @@ updates:
       time: '06:00'
       timezone: Europe/Paris
     open-pull-requests-limit: 5
+    groups:
+      # init and analyze must move together: CodeQL aborts with "Loaded a configuration file for
+      # version X, but running version Y" when the halves disagree, so a per-action PR is red on
+      # arrival and can never be merged alone.
+      codeql-action:
+        patterns:
+          - 'github/codeql-action*'

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -26,9 +26,9 @@ jobs:
 
       # JavaScript analysis is source-based; skipping a native Electron build keeps this scan
       # portable while the Windows CI workflow validates the runtime test suites.
-      - uses: github/codeql-action/init@5595ccaf912efad79be6eef63a5619ff05969be3 # v4
+      - uses: github/codeql-action/init@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4
         with:
           languages: javascript-typescript
           build-mode: none
 
-      - uses: github/codeql-action/analyze@5595ccaf912efad79be6eef63a5619ff05969be3 # v4
+      - uses: github/codeql-action/analyze@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4


### PR DESCRIPTION
## Problem

Dependabot split the `codeql-action` 4.37.6 → 4.37.7 bump into two PRs — #27 for
`init`, #28 for `analyze`. The workflow pins both halves to the same SHA, so either
PR alone puts them on different versions and CodeQL aborts before analysing:

```
##[error]Loaded a configuration file for version '4.37.6', but running version '4.37.7'
##[error]analyze post-action step failed: Loaded a configuration file for version '4.37.6', but running version '4.37.7'
```

Both PRs were red on arrival and neither can be merged on its own. Confirmed in the
failing runs for each branch.

## What changed

- Move `init` and `analyze` to `ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd` together.
  Both #27 and #28 target that same SHA, so this is exactly their union.
- Group `github/codeql-action*` in `dependabot.yml` so the next bump arrives as one
  reviewable PR rather than two that can only fail.

Supersedes #27 and #28.

## Validation

Both YAML files parse. The CodeQL run on this branch is the real check — a green
`Analyze JavaScript` here is what the split PRs could not produce.